### PR TITLE
Updated script to get command parameters from site.json file.

### DIFF
--- a/wordpress/Get-WordPressCoreFiles.ps1
+++ b/wordpress/Get-WordPressCoreFiles.ps1
@@ -9,24 +9,28 @@ Param(
     [ValidateNotNullOrEmpty()]
     [String] $Path,
 
-    # WordPress version to be downloaded. latest (default) and nightly are valid
-    [Parameter (Mandatory=$false)]
-    [String] $Version,
-
-    # WordPress locale. Default is en_US
-    [Parameter (Mandatory=$false)]
-    [String] $Locale
+    # WordPress site config in JSON string format
+    [Parameter (Mandatory=$true)]
+    [ValidateNotNullOrEmpty()]
+    [String] $SiteConfig
 )
 
+# Parse site configuration
+$SiteConfigJson = ConvertFrom-Json $SiteConfig
+
+# Set/expand variables before using WP CLI
+$_version = $SiteConfigJson.settings.version
+$_locale = $SiteConfigJson.settings.locale
+
 # Set latest version if not provided
-if ([String]::IsNullOrEmpty($Version)) {
-    $Version = 'latest'
+if ([String]::IsNullOrEmpty($_version)) {
+    $_version = 'latest'
 }
 
 # Set en_US locale if not provided
-if ([String]::IsNullOrEmpty($Locale)) {
-    $Version = 'en_US'
+if ([String]::IsNullOrEmpty($_locale)) {
+    $_locale = 'en_US'
 }
 
 # Download WordPress without the default themes and plugins
-wp core download --version=$Version --locale=$Locale --path=$Path --skip-content
+wp core download --version=$_version --locale=$_locale --path=$Path --skip-content


### PR DESCRIPTION
`$Version` and `$Locale` parameters deleted and added the `site.json` content as a parameter in order to get the neccesary properties and engage them to the `wp core download` command.