### PR TITLE
Fixed code smells. Covered artifacts.py with unit tests

### DIFF
--- a/devops_platforms/azuredevops/artifacts.py
+++ b/devops_platforms/azuredevops/artifacts.py
@@ -1,6 +1,5 @@
 """Artifacts-related functionality"""
 
-import os
 import tools.cli as cli
 from core.app import App
 from core.CommandsCore import CommandsCore

--- a/devops_platforms/azuredevops/tests/artifacts_test.py
+++ b/devops_platforms/azuredevops/tests/artifacts_test.py
@@ -1,0 +1,60 @@
+"""Unit tests for the artifacts.py file"""
+
+import json
+from unittest.mock import patch, call
+from core.app import App
+from core.CommandsCore import CommandsCore
+from core.LiteralsCore import LiteralsCore
+from devops_platforms.azuredevops.Literals import Literals as PlatformSpecificLiterals
+from devops_platforms.azuredevops.commands import Commands as PlatformSpecificCommands
+
+import devops_platforms.azuredevops.artifacts as sut
+
+app: App = App()
+literals = LiteralsCore([PlatformSpecificLiterals])
+commands = CommandsCore([PlatformSpecificCommands])
+
+# region download_artifact_from_feed()
+
+
+@patch("logging.warning")
+@patch("logging.error")
+def test_download_artifact_from_feed_given_kwargs_when_not_azdevops_token_then_logs(
+        logging_err_mock, logging_warn_mock, artifactsdata):
+    """Given kwargs, when not azdevops_token present, then should log and return"""
+    # Arrange
+    kwargs = dict()
+    kwargs["not_azdevops_token"] = "some_value"
+    feed_config = json.loads(artifactsdata.feed_content)
+    destination_path = artifactsdata.artifact_destination_path
+    expected_error = literals.get("azdevops_token_not_found")
+    # Act
+    sut.download_artifact_from_feed(feed_config, destination_path, **kwargs)
+    # Assert
+    logging_err_mock.assert_called_once_with(expected_error)
+
+
+@patch("tools.cli.call_subprocess")
+def testdownload_artifact_from_feed_given_kwargs_when_azdevops_token_calls_commands(subprocess_mock, artifactsdata):
+    """Given kwargs, when azdevops_token present, then calls azdevops_login and azdevops_universal_download"""
+    # Arrange
+    kwargs = dict()
+    kwargs["azdevops_token"] = "my_token"
+    feed_config = json.loads(artifactsdata.feed_content)
+    destination_path = artifactsdata.artifact_destination_path
+    expected_azdevops_login_command = commands.get("azdevops_login")\
+        .format(token=kwargs["azdevops_token"], organization=feed_config["organization_url"])
+    expected_azdevops_univ_download = commands.get("azdevops_universal_download")\
+        .format(feed=feed_config["name"],
+                name=feed_config["package"],
+                path=f"\"{destination_path}\"",
+                version=feed_config["version"],
+                organization=feed_config["organization_url"])
+
+    # Act
+    sut.download_artifact_from_feed(feed_config, destination_path, **kwargs)
+    # Assert
+    expected_calls = [call(expected_azdevops_login_command), call(expected_azdevops_univ_download)]
+    subprocess_mock.assert_has_calls(expected_calls)
+
+# endregion

--- a/devops_platforms/azuredevops/tests/conftest.py
+++ b/devops_platforms/azuredevops/tests/conftest.py
@@ -8,7 +8,18 @@ class PlatformData(object):
     description = "Lorem ipsum dolor sit amet"
 
 
+class ArtifactsData(object):
+    """Class used to create the artifactsdata fixture"""
+    artifact_destination_path = "/pathto/artifact/destination"
+    feed_content = "{\"name\":\"feed_name\",\"package\":\"package_name\",\"version\":\"1.0.1\"," \
+                   "\"organization_url\":\"https://my-organization\"}"
+
 @pytest.fixture
 def platformdata():
     """Sample data for testing"""
     return PlatformData()
+
+@pytest.fixture
+def artifactsdata():
+    """Sample data for testing"""
+    return ArtifactsData()

--- a/filesystem/paths.py
+++ b/filesystem/paths.py
@@ -233,13 +233,6 @@ def is_valid_path(path: str = None, check_existence: bool = False) -> bool:
     if check_existence and not os.path.exists(path):
         return False
 
-    path_object = pathlib.Path(path)
-
-    # Exception for unit tests
-    if not path.startswith("/pathto") \
-            and not pathlib.Path.exists(path_object):
-        return False
-
     return True
 
 

--- a/filesystem/tests/parsers_test.py
+++ b/filesystem/tests/parsers_test.py
@@ -64,8 +64,7 @@ def test_parse_theme_metadata_when_tokens_matched_then_return_matches_dict(loggi
     """ Given theme metadata, when tokens to match, then return matches as a dict"""
     # Arrange
     token1, value1, token2, value2 = "Sometoken1", "Somevalue1", "Sometoken2", "Somevalue2"
-    tokens = dict()
-    tokens[token1], tokens[token2] = value1, value2
+    tokens = [token1, token2]
     css_file_data = b"Sometoken1: Somevalue1\r\nSometoken2: Somevalue2\r\n"
     # Act
     result = sut.parse_theme_metadata(css_file_data, tokens)
@@ -81,12 +80,11 @@ def test_parse_theme_metadata_when_token_and_not_matched_then_warns(
     """ Given theme metadata, when token present and doest match, then return matches as a dict"""
     # Arrange
     token1, value1 = "Sometoken1", "Somevalue1"
-    tokens = dict()
-    tokens[token1] = value1
+    tokens = [token1]
     css_file_data = b"Sometoken2: Somevalue2\r\n"
     literal_expected = wp_literals.get("wp_parsing_theme_no_matches_found").format(token=token1)
     # Act
-    result = sut.parse_theme_metadata(css_file_data, tokens)
+    sut.parse_theme_metadata(css_file_data, tokens)
     # Assert
     logging_warning_mock.assert_called_once_with(literal_expected)
 

--- a/filesystem/tests/paths_test.py
+++ b/filesystem/tests/paths_test.py
@@ -304,7 +304,7 @@ def test_is_valid_path_given_non_existent_path_returns_false(paths):
     path = paths.non_existent_path
 
     # Act
-    result = sut.is_valid_path(path)
+    result = sut.is_valid_path(path, True)
 
     # Assert
     assert not result

--- a/project_types/wordpress/tests/parse_theme_metadata_test.py
+++ b/project_types/wordpress/tests/parse_theme_metadata_test.py
@@ -16,7 +16,7 @@ def test_parse_theme_metadata_from_path_when_path_exists_then_calls_parse_theme_
     tokens[token1], tokens[token2] = value1, value2
     css_file_data = b"Sometoken1: Somevalue1\r\nSometoken2: Somevalue2\r\n"
     # Act
-    with patch("builtins.open", new_callable=mock_open, read_data=css_file_data) as file_data:
+    with patch("builtins.open", new_callable=mock_open, read_data=css_file_data):
         sut.main(css_file_path, tokens)
         # Assert
         parse_theme_metadata_mock.assert_called_once_with(css_file_data, tokens, True)

--- a/tools/git.py
+++ b/tools/git.py
@@ -122,7 +122,7 @@ def git_init(path: str, skip: bool):
 def purge_gitkeep(path: str = None):
     """Deletes .gitkeep file if exists and there are more files in the path."""
 
-    if not filesystem.paths.is_valid_path(path):
+    if not filesystem.paths.is_valid_path(path, True):
         raise ValueError(literals.get("git_non_valid_dir_path"))
 
     path_object = pathlib.Path(path)


### PR DESCRIPTION
- Covered artifacts.py in order to fix the smell of the 65% tests threshold.
- Removed non used branch on is_valid_path
- Adapted some tests to include is_valid_path's new "checkexistance" parameter