### PR TITLE
Feature/project structure by default

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -37,6 +37,7 @@ def filenames():
     """Sample file names for testing file system related functionality"""
     return FileNames()
 
+
 @pytest.fixture
 def mocks():
     """ General testing mocks """

--- a/devops_platforms/constants.py
+++ b/devops_platforms/constants.py
@@ -13,7 +13,7 @@ class Urls(object):
     DEFAULT_SITE_ENVIRONMENTS = GITHUB_RAW_CONTENT + \
         "project_types/wordpress/default-files/default-site-environments.json"
     DEFAULT_WORDPRESS_PROJECT_STRUCTURE = \
-        GITHUB_RAW_CONTENT + "project_types/wordpress/default-wordpress-project-structure.json"
+        GITHUB_RAW_CONTENT + "project_types/wordpress/default-files/default-wordpress-project-structure.json"
 
     bootstrap_required_files = {
         "*site.json": DEFAULT_SITE_CONFIG,

--- a/devops_platforms/constants.py
+++ b/devops_platforms/constants.py
@@ -4,13 +4,14 @@
 class Urls(object):
     """URL constants"""
     GITHUB_RAW_CONTENT = "https://raw.githubusercontent.com/aheadlabs/devops-toolset/master/"
-    DEVOPS_TOOLSET_MASTER = GITHUB_RAW_CONTENT + "project_types/wordpress/default-project.xml"
+    DEVOPS_TOOLSET_MASTER = GITHUB_RAW_CONTENT + "project_types/wordpress/default-files/default-project.xml"
     SONAR_QUALITY_GATE_PARTIAL_URL = "/api/qualitygates/project_status?projectKey="
-    DEFAULT_PROJECT_XML = GITHUB_RAW_CONTENT + "project_types/wordpress/default-project.xml"
-    DEFAULT_README = GITHUB_RAW_CONTENT + "project_types/wordpress/default-README.md"
-    DEFAULT_GITIGNORE = GITHUB_RAW_CONTENT + "project_types/wordpress/default.gitignore"
-    DEFAULT_SITE_CONFIG = GITHUB_RAW_CONTENT + "project_types/wordpress/default-localhost-site.json"
-    DEFAULT_SITE_ENVIRONMENTS = GITHUB_RAW_CONTENT + "project_types/wordpress/default-site-environments.json"
+    DEFAULT_PROJECT_XML = GITHUB_RAW_CONTENT + "project_types/wordpress/default-files/default-project.xml"
+    DEFAULT_README = GITHUB_RAW_CONTENT + "project_types/wordpress/default-files/default-README.md"
+    DEFAULT_GITIGNORE = GITHUB_RAW_CONTENT + "project_types/wordpress/default-files/default.gitignore"
+    DEFAULT_SITE_CONFIG = GITHUB_RAW_CONTENT + "project_types/wordpress/default-files/default-localhost-site.json"
+    DEFAULT_SITE_ENVIRONMENTS = GITHUB_RAW_CONTENT + \
+        "project_types/wordpress/default-files/default-site-environments.json"
     DEFAULT_WORDPRESS_PROJECT_STRUCTURE = \
         GITHUB_RAW_CONTENT + "project_types/wordpress/default-wordpress-project-structure.json"
 

--- a/project.xml
+++ b/project.xml
@@ -1,5 +1,5 @@
 <project>
     <name>devops-toolset</name>
-    <version>0.43.0</version>
+    <version>0.43.1</version>
     <organization>aheadlabs</organization>
 </project>

--- a/project_types/wordpress/constants.py
+++ b/project_types/wordpress/constants.py
@@ -2,8 +2,7 @@
 
 required_files_suffixes = {
     "site_configuration_file_path": "site.json",
-    "site_environments_file_path": "site-environments.json",
-    "project_structure_file_path": "project-structure.json"
+    "site_environments_file_path": "site-environments.json"
 }
 
 theme_metadata_parse_regex = ":\s([\w\d\sáéíóú'-.]+)\r\n"

--- a/project_types/wordpress/generate_wordpress.py
+++ b/project_types/wordpress/generate_wordpress.py
@@ -55,7 +55,7 @@ def main(root_path: str, db_user_password: str, db_admin_password: str, wp_admin
     root_path_obj = pathlib.Path(root_path)
     database_path = global_constants["paths"]["database"]
 
-    # Look for *site.json, *site-environments.json and *project-structure.json files in the project path
+    # Look for *site.json and *site-environments.json files in the project path
     required_files_pattern_suffixes = list(map(lambda x: f"*{ x[1]}", constants.required_files_suffixes.items()))
     required_files_not_present = paths.files_exist_filtered(root_path, False, required_files_pattern_suffixes)
 
@@ -103,7 +103,7 @@ def main(root_path: str, db_user_password: str, db_admin_password: str, wp_admin
     themes_path = wordpress.wptools.get_themes_path_from_root_path(root_path)
 
     # Create project structure & prepare devops-toolset
-    wordpress.wptools.start_basic_project_structure(root_path, project_structure_file_path)
+    wordpress.wptools.start_basic_project_structure(root_path)
 
     # Check for updates / download devops-toolset
     setup_devops_toolset(root_path)

--- a/project_types/wordpress/generate_wordpress.py
+++ b/project_types/wordpress/generate_wordpress.py
@@ -89,7 +89,6 @@ def main(root_path: str, db_user_password: str, db_admin_password: str, wp_admin
     required_file_paths = wordpress.wptools.get_required_file_paths(
         root_path, required_files_pattern_suffixes)
     environment_file_path = required_file_paths[1]
-    project_structure_file_path = required_file_paths[2]
 
     # Get database admin user from environment
     db_admin_user = wordpress.wptools.get_db_admin_from_environment(environment_file_path, environment)

--- a/project_types/wordpress/generate_wordpress.py
+++ b/project_types/wordpress/generate_wordpress.py
@@ -64,9 +64,8 @@ def main(root_path: str, db_user_password: str, db_admin_password: str, wp_admin
         core.log_tools.log_indented_list(literals.get("wp_required_files_not_found_detail").format(path=root_path),
                                          required_files_not_present, core.log_tools.LogLevel.warning)
 
-        core.log_tools.log_indented_list(literals.get("wp_default_files"), [
-            Urls.DEFAULT_WORDPRESS_PROJECT_STRUCTURE, Urls.DEFAULT_SITE_ENVIRONMENTS, Urls.DEFAULT_SITE_CONFIG],
-                                         core.log_tools.LogLevel.info)
+        core.log_tools.log_indented_list(literals.get("wp_default_files"), [Urls.DEFAULT_SITE_ENVIRONMENTS,
+            Urls.DEFAULT_SITE_CONFIG], core.log_tools.LogLevel.info)
 
         # Ask to use defaults
         use_defaults = prompt.yn(literals.get("wp_use_default_files"))

--- a/project_types/wordpress/tests/conftest.py
+++ b/project_types/wordpress/tests/conftest.py
@@ -152,7 +152,9 @@ class WordPressData:
     condition_key = 'condition'
     dump_file_path = "/pathto/dump_file_1.sql"
     path = "/pathto"
+    url_resource = "https://url/resource"
     default_pwd = "root"
+
 
 
 @pytest.fixture
@@ -190,8 +192,26 @@ def mocked_requests_get(url: str, *args, **kwargs):
     return MockResponse(bytes_content, text_content)
 
 
+def mocked_requests_get_json_content(url: str, *args, **kwargs):
+    """Mock to replace requests.get()"""
+
+    # Return instance
+    return MockJsonResponse(WordPressData.structure_file_content)
+
+
 class MockResponse:
     """This is the mocked Response object returned by requests.get()"""
     def __init__(self, b_content, text_content):
         self.content = b_content
         self.text = text_content
+
+
+class MockJsonResponse:
+    """This is the mocked Response object returned by requests.get()"""
+    def __init__(self, json_content):
+        self.json_content = json_content
+
+    def json(self):
+        return self.json_content
+
+

--- a/project_types/wordpress/tests/wptools_test.py
+++ b/project_types/wordpress/tests/wptools_test.py
@@ -6,10 +6,12 @@ import json
 import pathlib
 import project_types.wordpress.wptools as sut
 from project_types.wordpress.basic_structure_starter import BasicStructureStarter
+from devops_platforms import constants as devops_platform_constants
 from core.LiteralsCore import LiteralsCore
 from project_types.wordpress.Literals import Literals as WordpressLiterals
 from unittest.mock import patch, mock_open, call
-from project_types.wordpress.tests.conftest import WordPressData, ThemesData, mocked_requests_get, PluginsData
+from project_types.wordpress.tests.conftest import WordPressData, ThemesData, mocked_requests_get, \
+    mocked_requests_get_json_content, PluginsData
 
 literals = LiteralsCore([WordpressLiterals])
 
@@ -301,15 +303,15 @@ def test_get_db_admin_from_environment_return_db_admin_user_from_environment_fil
 # region get_project_structure()
 
 
-@patch("builtins.open", new_callable=mock_open, read_data=WordPressData.structure_file_content)
-def test_get_project_structure_given_path_reads_and_parses_content(open_file_mock, wordpressdata):
-    """Given a path, reads the file and parses the JSON content."""
+def test_get_project_structure_given_resource_reads_and_parses_content(wordpressdata, mocks):
+    """Given a path, reads the file obtained from the resource and parses the JSON content."""
 
     # Arrange
-    path = wordpressdata.project_structure_path
+    url_resource = wordpressdata.url_resource
+    mocks.requests_get_mock.side_effect = mocked_requests_get_json_content
 
     # Act
-    result = sut.get_project_structure(path)
+    result = sut.get_project_structure(url_resource)
 
     # Assert
     assert result == json.loads(WordPressData.structure_file_content)
@@ -825,13 +827,13 @@ def test_install_wordpress_site_then_calls_cli_export_database(
 def test_main_given_parameters_must_call_wptools_get_project_structure(get_project_structure_mock, wordpressdata):
     """Given arguments, must call get_project_structure with passed project_path"""
     # Arrange
-    project_structure_path = wordpressdata.project_structure_path
+    project_structure_resource = devops_platform_constants.Urls.DEFAULT_WORDPRESS_PROJECT_STRUCTURE
     root_path = wordpressdata.wordpress_path
     get_project_structure_mock.return_value = {"items": {}}
     # Act
-    sut.start_basic_project_structure(root_path, project_structure_path)
+    sut.start_basic_project_structure(root_path)
     # Assert
-    get_project_structure_mock.assert_called_once_with(project_structure_path)
+    get_project_structure_mock.assert_called_once_with(project_structure_resource)
 
 
 @patch.object(sut, "get_project_structure")
@@ -839,12 +841,11 @@ def test_main_given_parameters_must_call_wptools_get_project_structure(get_proje
 def test_main_given_parameters_must_call_add_item(add_item_mock, get_project_structure_mock, wordpressdata):
     """Given arguments, must call get_project_structure with passed project_path"""
     # Arrange
-    project_structure_path = wordpressdata.project_structure_path
     root_path = wordpressdata.wordpress_path
     items_data = {"items": {'foo_item': 'foo_value'}}
     get_project_structure_mock.return_value = items_data
     # Act
-    sut.start_basic_project_structure(root_path, project_structure_path)
+    sut.start_basic_project_structure(root_path)
     # Assert
     add_item_mock.assert_called_once_with('foo_item', root_path)
 

--- a/project_types/wordpress/tests/wptools_test.py
+++ b/project_types/wordpress/tests/wptools_test.py
@@ -314,7 +314,7 @@ def test_get_project_structure_given_resource_reads_and_parses_content(wordpress
     result = sut.get_project_structure(url_resource)
 
     # Assert
-    assert result == json.loads(WordPressData.structure_file_content)
+    assert result == WordPressData.structure_file_content
 
 
 # endregion

--- a/project_types/wordpress/wptools.py
+++ b/project_types/wordpress/wptools.py
@@ -282,8 +282,7 @@ def get_project_structure(url_resource: str) -> dict:
         Project structure in a dict object.
     """
     request = requests.get(url_resource)
-    data = request.json()
-    return json.loads(data)
+    return request.json()
 
 
 def get_required_file_paths(path: str, required_file_patterns: List[str]) -> Tuple:

--- a/project_types/wordpress/wptools.py
+++ b/project_types/wordpress/wptools.py
@@ -21,6 +21,7 @@ from core.CommandsCore import CommandsCore
 from core.LiteralsCore import LiteralsCore
 from project_types.wordpress.Literals import Literals as WordpressLiterals
 from devops_platforms.azuredevops.Literals import Literals as PlatformLiterals
+from devops_platforms import constants as devops_platforms_constants
 from project_types.wordpress.commands import Commands as WordpressCommands
 from tools import cli
 from typing import List, Tuple
@@ -268,21 +269,21 @@ def get_constants() -> dict:
     return data
 
 
-def get_project_structure(path: str) -> dict:
-    """Gets the project structure from a WordPress project structure file.
+def get_project_structure(url_resource: str) -> dict:
+    """Gets the project structure from a WordPress project structure file located on an url resource.
 
     For more information see:
         http://dev.aheadlabs.com/schemas/json/project-structure-schema.json
 
     Args:
-        path: Full path to the WordPress project structure file.
+        url_resource: Full url resource to the WordPress project structure file.
 
     Returns:
         Project structure in a dict object.
     """
-    with open(path, "r") as project_structure_file:
-        data = project_structure_file.read()
-        return json.loads(data)
+    request = requests.get(url_resource)
+    data = request.json()
+    return json.loads(data)
 
 
 def get_required_file_paths(path: str, required_file_patterns: List[str]) -> Tuple:
@@ -805,18 +806,17 @@ def setup_database(site_config: dict, wordpress_path: str, db_user_password: str
         wordpress_path, admin_db_user, admin_db_password, db_user, db_user_password, schema, db_host)
 
 
-def start_basic_project_structure(root_path: str, project_structure_path: str) -> None:
+def start_basic_project_structure(root_path: str) -> None:
     """ Creates a basic structure of a wordpress project based on the project-structure.json
 
     Args:
         root_path: Full path where the structure will be created
-        project_structure_path: Full path to the json containing the structure
     """
 
     logging.info(literals.get("wp_creating_project_structure"))
 
     # Parse project structure configuration
-    project_structure = get_project_structure(project_structure_path)
+    project_structure = get_project_structure(devops_platforms_constants.Urls.DEFAULT_WORDPRESS_PROJECT_STRUCTURE)
     project_starter = BasicStructureStarter()
 
     # Iterate through every item recursively


### PR DESCRIPTION
Project structure is now generated using the default file at project level and will not be taking a custom file, so it's no longer required to be on the initial files to bootstrap the WordPress repository.