### PR TITLE
Hotfix/1048 fix content issue

### DIFF
--- a/json-schemas/wordpress-site-schema.json
+++ b/json-schemas/wordpress-site-schema.json
@@ -418,7 +418,11 @@
       },
       "default": []
     },
-    "content": {"type": "array", "contains":  {"type" : "string" }}
+    "content": {
+      "type": "array",
+      "contains":  {"type" : "string" },
+      "default": []
+    }
   },
   "required": [
     "wp_cli",

--- a/project_types/wordpress/tests/wptools_test.py
+++ b/project_types/wordpress/tests/wptools_test.py
@@ -386,6 +386,23 @@ def test_import_content_from_configuration_file_given_args_then_call_delete_post
     # Assert
     delete_content_mock.assert_has_calls(expected_calls)
 
+
+@patch("project_types.wordpress.wp_cli.import_wxr_content")
+@patch("project_types.wordpress.wp_cli.delete_post_type_content")
+@patch("project_types.wordpress.wptools.get_constants")
+def test_import_content_from_configuration_file_given_args_when_no_content_then_return(get_constants_mock,
+    delete_content_mock, import_wxr_content, wordpressdata):
+    """ Given args, when no content key supplied inside site_config_content, should not call any mock """
+    # Arrange
+    site_config = json.loads(wordpressdata.site_config_content)
+    site_config.pop('content', None)
+    get_constants_mock.return_value = json.loads(wordpressdata.constants_file_content)
+    wordpress_path = wordpressdata.wordpress_path
+    # Act
+    sut.import_content_from_configuration_file(site_config, wordpress_path)
+    # Assert
+    import_wxr_content.assert_not_called()
+
 # endregion import_content_from_configuration_file
 
 # region install_plugins_from_configuration_file()

--- a/project_types/wordpress/wptools.py
+++ b/project_types/wordpress/wptools.py
@@ -355,6 +355,9 @@ def import_content_from_configuration_file(site_configuration: dict, wordpress_p
         site_configuration: parsed site configuration.
         wordpress_path: Path to WordPress files.
     """
+    if "content" not in site_configuration:
+        return
+
     # Add constants
     constants = get_constants()
 


### PR DESCRIPTION
Fixed bug on import content settings, now the process will ignore the importing of content if the `content `node is not present inside `site_configuration.json` file.