### PR TITLE
Fixed bug regarding import_content

### DIFF
--- a/filesystem/tests/parsers_test.py
+++ b/filesystem/tests/parsers_test.py
@@ -65,7 +65,7 @@ def test_parse_theme_metadata_when_tokens_matched_then_return_matches_dict(loggi
     # Arrange
     token1, value1, token2, value2 = "Sometoken1", "Somevalue1", "Sometoken2", "Somevalue2"
     tokens = [token1, token2]
-    css_file_data = b"Sometoken1: Somevalue1\r\nSometoken2: Somevalue2\r\n"
+    css_file_data = b"Sometoken1: Somevalue1\nSometoken2: Somevalue2\n"
     # Act
     result = sut.parse_theme_metadata(css_file_data, tokens)
     # Assert
@@ -81,7 +81,7 @@ def test_parse_theme_metadata_when_token_and_not_matched_then_warns(
     # Arrange
     token1, value1 = "Sometoken1", "Somevalue1"
     tokens = [token1]
-    css_file_data = b"Sometoken2: Somevalue2\r\n"
+    css_file_data = b"Sometoken2: Somevalue2\n"
     literal_expected = wp_literals.get("wp_parsing_theme_no_matches_found").format(token=token1)
     # Act
     sut.parse_theme_metadata(css_file_data, tokens)
@@ -98,7 +98,7 @@ def test_parse_theme_metadata_when_tokens_matched_and_add_environment_variables_
     tokens, env_variable = dict(), dict()
     token, value = "Sometoken", "Somevalue"
     tokens[token] = value
-    css_file_data = b"Sometoken: Somevalue\r\n"
+    css_file_data = b"Sometoken: Somevalue\n"
     env_variable[f"theme_{token}".upper()] = value
     # Act
     with patch.object(sut, "platform_specific") as platform_specific_mock:

--- a/project.xml
+++ b/project.xml
@@ -1,5 +1,5 @@
 <project>
     <name>devops-toolset</name>
-    <version>0.44.0</version>
+    <version>0.44.1</version>
     <organization>aheadlabs</organization>
 </project>

--- a/project.xml
+++ b/project.xml
@@ -1,5 +1,5 @@
 <project>
     <name>devops-toolset</name>
-    <version>0.44.1</version>
+    <version>0.44.2</version>
     <organization>aheadlabs</organization>
 </project>

--- a/project_types/wordpress/tests/conftest.py
+++ b/project_types/wordpress/tests/conftest.py
@@ -21,16 +21,16 @@ class PluginsData:
 
 class ThemesData:
     """Class used to create the themesdata fixture"""
-    default_scss_file_example = "/*!\r\nTheme Name: MyTheme WordPress theme\r\nTheme URI: https://example.com/\r\n" \
-                                "Description: Ad hoc WordPres theme.\r\nAuthor: Ahead Labs, S.L.\r\nAuthor URI: " \
-                                "https://aheadlabs.com\r\nTags: ahead-labs, theme\r\nVersion: {{version}}\r\n" \
-                                "Requires at least: 5.6\r\nTested up to: 5.6\r\nRequires PHP: 7.4.11\r\n" \
-                                "License: Copyright\r\nText Domain: mytheme\r\nTemplate: w74-framework\r\n*/"
-    default_scss_file_expected = "/*!\r\nTheme Name: theme\r\nTheme URI: https://mytheme\r\n" \
-                                "Description: mytheme-description\r\nAuthor: theme-author\r\nAuthor URI: " \
-                                "https://example.com\r\nTags: tag1, tag2\r\nVersion: {{version}}\r\n" \
-                                "Requires at least: 5.6\r\nTested up to: 5.6\r\nRequires PHP: 7.4.11\r\nLicense: Copyright\r\n" \
-                                "Text Domain: mytheme\r\nTemplate: w74-framework\r\n*/"
+    default_scss_file_example = "/*!\nTheme Name: MyTheme WordPress theme\nTheme URI: https://example.com/\n" \
+                                "Description: Ad hoc WordPres theme.\nAuthor: Ahead Labs, S.L.\nAuthor URI: " \
+                                "https://aheadlabs.com\nTags: ahead-labs, theme\nVersion: {{version}}\n" \
+                                "Requires at least: 5.6\nTested up to: 5.6\nRequires PHP: 7.4.11\n" \
+                                "License: Copyright\nText Domain: mytheme\nTemplate: w74-framework\n*/"
+    default_scss_file_expected = "/*!\nTheme Name: theme\nTheme URI: https://mytheme\n" \
+                                "Description: mytheme-description\nAuthor: theme-author\nAuthor URI: " \
+                                "https://example.com\nTags: tag1, tag2\nVersion: {{version}}\n" \
+                                "Requires at least: 5.6\nTested up to: 5.6\nRequires PHP: 7.4.11\nLicense: Copyright\n" \
+                                "Text Domain: mytheme\nTemplate: w74-framework\n*/"
     default_functions_core_php_example = "function mytheme_register_styles()\n{\n\n}\nadd_action('wp_enqueue_scripts', " \
                                          "'mytheme_register_styles')"
     default_functions_core_php_example_expected = "function mytheme_replaced_register_styles()\n{\n\n}\n" \

--- a/project_types/wordpress/wp_theme_tools.py
+++ b/project_types/wordpress/wp_theme_tools.py
@@ -348,7 +348,7 @@ def replace_theme_meta_data(path: str, replacements: dict, regex_str: str):
         regex_str: The regex string used to match and replace the replacements dict.
     """
 
-    replace_file = open(path, 'r', newline='\r\n')
+    replace_file = open(path, 'r', newline='\n')
     file_content = replace_file.read()
 
     for key, replacement in replacements.items():
@@ -361,7 +361,7 @@ def replace_theme_meta_data(path: str, replacements: dict, regex_str: str):
 
         if matches is not None and matches.group(1):
             # Build the replacement string
-            target = f'{matches.group(1)}: {replacement}\r\n'
+            target = f'{matches.group(1)}: {replacement}'
             # Apply the replacement
             file_content = file_content.replace(matches.group(0), target)
 


### PR DESCRIPTION
Fixed `bug `regarding importing content:

- `content `node now can be empty on `site_configuration.json` (fixed associated `json_schema`)
- Importing will be ignored if `content `node is not present inside `site_configuration.json` file
- Upgraded patch version to `0.44.2`