### PR TITLE
fix: preserve URLs in JSONC comment stripping

### DIFF
--- a/src/devops_toolset/saas_platforms/github/inject_secrets_and_variables.py
+++ b/src/devops_toolset/saas_platforms/github/inject_secrets_and_variables.py
@@ -60,11 +60,13 @@ class Secret:
 
 def strip_jsonc_comments(content: str) -> str:
     """
-    Remove comments from JSONC content.
+    Remove comments from JSONC content while preserving strings.
     
     Supports:
     - Line comments: // comment
     - Block comments: /* comment */
+    
+    This implementation properly handles // inside JSON strings (like URLs).
     
     Args:
         content: JSONC file content
@@ -72,13 +74,53 @@ def strip_jsonc_comments(content: str) -> str:
     Returns:
         JSON content without comments
     """
-    # Remove block comments /* ... */
-    content = re.sub(r'/\*.*?\*/', '', content, flags=re.DOTALL)
+    result = []
+    i = 0
+    in_string = False
+    escape_next = False
     
-    # Remove line comments // ...
-    content = re.sub(r'//.*$', '', content, flags=re.MULTILINE)
+    while i < len(content):
+        # Handle escape sequences
+        if escape_next:
+            result.append(content[i])
+            escape_next = False
+            i += 1
+            continue
+        
+        # Check for escape character
+        if content[i] == '\\':
+            result.append(content[i])
+            escape_next = True
+            i += 1
+            continue
+        
+        # Toggle string state
+        if content[i] == '"':
+            in_string = not in_string
+            result.append(content[i])
+            i += 1
+            continue
+        
+        # Skip comments only if not in string
+        if not in_string:
+            # Block comment
+            if i < len(content) - 1 and content[i:i+2] == '/*':
+                # Find end of block comment
+                end = content.find('*/', i + 2)
+                if end != -1:
+                    i = end + 2
+                    continue
+            # Line comment
+            elif i < len(content) - 1 and content[i:i+2] == '//':
+                # Skip to end of line
+                while i < len(content) and content[i] != '\n':
+                    i += 1
+                continue
+        
+        result.append(content[i])
+        i += 1
     
-    return content
+    return ''.join(result)
 
 
 def load_template(template_path: Path) -> Dict[str, Any]:


### PR DESCRIPTION
## Problem

The `strip_jsonc_comments` function in `inject_secrets_and_variables.py` was using a naive regex pattern (`r'//.*$'`) that removed everything after `//` on each line. This broke Azure Key Vault URLs in JSON strings like:
```
https://kv-ahl-secr-weu-shr-01.vault.azure.net/secrets/github-admin-token
```

The URLs were being truncated to just `https:` because the `//` was treated as a comment marker.

## Solution

This PR contains two commits:

### 1. **Commit 7021cb2**: Fix strip_jsonc_comments function
Rewrote the function with a proper character-by-character parser that:
- Tracks whether we're inside a JSON string
- Handles escape sequences properly (`\"`, `\\`)
- Only removes `//` comments when not inside a string
- Preserves all URLs and other `//`-containing values

### 2. **Commit c853f8d**: Add reusable extract_azure_credentials script
Created a new standalone script for extracting Azure credentials from JSONC templates:
- Reuses the fixed `strip_jsonc_comments` function
- Outputs to GITHUB_OUTPUT for workflow integration
- Supports multiple output formats (github-actions, json, env)
- Proper error handling and validation
- Can be called from workflows: `python -m devops_toolset.saas_platforms.github.extract_azure_credentials template.jsonc`

 This eliminates the need for embedded scripts in workflows and centralizes the logic.

## Testing

Created test script that confirms URLs are now properly preserved:
```
✅ SUCCESS! File parses correctly
GH_ADMIN_TOKEN URL: https://kv-ahl-secr-weu-shr-01.vault.azure.net/secrets/github-admin-token
✅ URLs are properly preserved!
```

## Related

- ahead-labs-software/.github#2 (centralizedworkflow now uses the new extract_azure_credentials script)

## Impact

This fixes the GitHub Actions workflow `setup-secrets-and-variables.yml` which was failing with "Invalid control character" errors when trying to parse corrupted Key Vault URLs. The new reusable script also improves workflow maintainability.